### PR TITLE
Store multiple foods

### DIFF
--- a/pages/Food.tsx
+++ b/pages/Food.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 const Food: NextPage = ({
   FavoriteFoods,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  const [listOfFoods, setListOfFoods] = useState(FavoriteFoods);
   const [sortedFoods, setSortedFoods] = useState(FavoriteFoods);
   const [text, setText] = useState("");
   const [sort, setSort] = useState("name");
@@ -26,10 +27,14 @@ const Food: NextPage = ({
     const newFood = sessionStorage.getItem("Food");
     if (newFood !== null) {
       const parsedNewFood = JSON.parse(newFood);
-      const newSorted = [...sortedFoods, parsedNewFood];
+      const newSorted = [...sortedFoods, ...parsedNewFood];
       setSortedFoods(newSorted);
+      setListOfFoods(newSorted);
       // localStorage.removeItem("Food");
     }
+    listOfFoods.forEach((data: Food) => {
+      console.log(data.id);
+    });
   }, []);
 
   const changeSort = (type: string) => {
@@ -53,7 +58,7 @@ const Food: NextPage = ({
   const filterFood = (text: string) => {
     setText(text);
     setSortedFoods(() => {
-      const tempFoods = FavoriteFoods.filter((food: Food) => {
+      const tempFoods = listOfFoods.filter((food: Food) => {
         if (food.name.toLowerCase().includes(text, 0)) {
           return food;
         }

--- a/pages/form/[formId].tsx
+++ b/pages/form/[formId].tsx
@@ -56,7 +56,20 @@ const FormPage: NextPage = ({
             name: data.name,
             image: data.image,
           };
-          sessionStorage.setItem(`${params.formId}`, JSON.stringify(formData));
+
+          const storedFood = sessionStorage.getItem("Food");
+          if (storedFood === null) {
+            const newFood = [];
+            newFood.push(formData);
+            sessionStorage.setItem(`${params.formId}`, JSON.stringify(newFood));
+          } else {
+            const parsedStoredFood = JSON.parse(storedFood);
+            sessionStorage.setItem(
+              `${params.formId}`,
+              JSON.stringify([...parsedStoredFood, formData])
+            );
+          }
+
           notify();
           setTimeout(() => {
             router.push(`/${params.formId}`);


### PR DESCRIPTION
Change local storage to session storage
Allows the app to store multiple foods even on refresh
Clear the session storage after closing the tab